### PR TITLE
Updated demos to use snooker

### DIFF
--- a/examples/demo/BART_eclipse.cfg
+++ b/examples/demo/BART_eclipse.cfg
@@ -47,10 +47,10 @@ pmax     = -1.0    1.0     1.0     1.0    1.2     1.5
 stepsize = 0.01    0.01    0.0     0.0    0.001   0.1
 
 # DEMC setup:
-numit       = 100000
-nchains     = 10
+numit       = 50000
+nchains     = 3
 burnin      = 500
-walk        = demc
+walk        = snooker
 leastsq     = False
 chisqscale  = False
 grtest      = True

--- a/examples/demo/BART_transit.cfg
+++ b/examples/demo/BART_transit.cfg
@@ -48,10 +48,10 @@ pmax     = -1.0    1.0     1.0     1.0    1.2    99000.0    1.5
 stepsize = 0.01    0.01    0.0     0.0    0.001     10.0    0.1
 
 # DEMC setup:
-numit       = 100000
-nchains     = 10
+numit       = 50000
+nchains     = 3
 burnin      = 500
-walk        = demc
+walk        = snooker
 leastsq     = False
 chisqscale  = False
 grtest      = True


### PR DESCRIPTION
Modified the eclipse and transit demo files to use snooker. Tested vs the previous version (used demc), it converges to the same answer much quicker, and uses less cores.